### PR TITLE
Added a user to the service file

### DIFF
--- a/docker/rootless_docker_nzgd_map.service
+++ b/docker/rootless_docker_nzgd_map.service
@@ -7,7 +7,9 @@ Description=NZGD Map Service
 # Starts the [Service] section, which controls how the service process executes and behaves.
 [Service]
 
-# Run the container as a user. <DOCKER_SOCKET_FOR_USER> is a four digit number given by
+# Run the service as a user. <USER> is the username of the user that will run the service.
+User=<USER>
+# <DOCKER_SOCKET_FOR_USER> is a four digit number given by
 # sudo loginctl enable-linger $(whoami)
 Environment="DOCKER_HOST=unix:///run/user/<DOCKER_SOCKET_FOR_USER>/docker.sock"
 


### PR DESCRIPTION
I forgot to specify the User when changing from running Docker as root to running Docker as a user, so I'm just adding the user specification to the service file 